### PR TITLE
Block validation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,6 @@ RUN npm install
 
 COPY . .
 
-EXPOSE 8888
+EXPOSE 8000
 
 CMD ["./start.sh"]

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ you will need to use the following endpoint:
 
 This endpoint will response with a message. With that message in hands, you will need to sign it using you preferred Bitcoin wallet (e.g Electrum) and do another request to the following endpoint:
 
-### POST /validate
+### POST /message-signature/validate
 
 ```
   {

--- a/handlers/block.js
+++ b/handlers/block.js
@@ -45,7 +45,13 @@ class Handler {
       return res.response({ error:  `the address #${auth.address} is not allowed to register a star` }).code(401);
     }
 
-    let newBlock = await this.chain.addBlock(new Block(req.payload));
+    let block = new Block(req.payload);
+
+    if (! block.isValid()) {
+      return res.response({ error: `invalid block`}).code(400);
+    }
+
+    let newBlock = await this.chain.addBlock(block);
 
     await auth.remove();
 

--- a/lib/block.js
+++ b/lib/block.js
@@ -6,6 +6,21 @@ class Block {
     this.time = 0
     this.previousBlockHash = ""
   }
+
+  fill(string) {
+    let parsed = JSON.parse(string);
+
+    this.hash = parsed.hash;
+    this.height = parsed.height;
+    this.body = parsed.body;
+    this.previousBlockHash = parsed.previousBlockHash;
+    this.time = parsed.time;
+ }
+
+  decodeStory() {
+    let decoded = Buffer.from(this.body.star.story, 'hex').toString();
+    this.body.star.storyDecoded = decoded;
+  }
 }
 
 module.exports = Block;

--- a/lib/block.js
+++ b/lib/block.js
@@ -18,8 +18,33 @@ class Block {
  }
 
   decodeStory() {
+    if (! this._hasStory()) {
+      return false;
+    }
+
     let decoded = Buffer.from(this.body.star.story, 'hex').toString();
     this.body.star.storyDecoded = decoded;
+  }
+
+  isValid() {
+    if (! this._hasStory()) {
+      return false;
+    }
+
+    let story = this.body.star.story;
+    let storyWords = story.split(' ').length;
+    let storyBytes = Buffer.byteLength(story, 'utf8');
+    let isAscii = this._isASCII(story);
+
+    return storyWords <= 250 && storyBytes <= 500 && isAscii
+  }
+
+  _isASCII(story) {
+    return /^[\x00-\x7F]*$/.test(story);
+  }
+
+  _hasStory() {
+    return this.body.star !== undefined && this.body.star.story !== undefined
   }
 }
 

--- a/lib/chain.js
+++ b/lib/chain.js
@@ -18,7 +18,7 @@ class Chain {
           star: {
             ra: 0,
             dec: 0,
-            storyDecoded: "The Times 00/00/00 The Big Bang just happened"
+            story: "The Times 00/00/00 The Big Bang just happened"
           }
         }
 
@@ -59,7 +59,7 @@ class Chain {
     }
 
     newBlock.hash = SHA256(JSON.stringify(newBlock)).toString();
-    newBlock.body.star.story = Buffer.from(newBlock.body.star.storyDecoded, 'utf8').toString('hex');
+    newBlock.body.star.story = Buffer.from(newBlock.body.star.story, 'utf8').toString('hex');
 
     let blockString = JSON.stringify(newBlock);
 
@@ -78,9 +78,12 @@ class Chain {
 
   async getBlock(blockHeight) {
     try {
-      let block = await this.chain.get(blockHeight);
+      let query = await this.chain.get(blockHeight);
+      let block = new Block("");
 
-      return JSON.parse(block);
+      block.fill(query);
+
+      return block;
     } catch(e) {
       return null;
     }
@@ -123,10 +126,13 @@ class Chain {
   }
 
   async getByHash(hash) {
-    let block = await this.chain.getByHash(hash);
+    let query = await this.chain.getByHash(hash);
+    let block = null;
 
-    if (block !== null) {
-      block = JSON.parse(block);
+    if (query !== null) {
+      block = new Block("");
+      block.fill(query);
+      block.decodeStory();
     }
 
     return block;
@@ -138,7 +144,9 @@ class Chain {
 
     if (items.length > 0) {
       for(var item of items) {
-        let block = JSON.parse(item);
+        let block = new Block("");
+        block.fill(item);
+        block.decodeStory();
         blocks.push(block);
       }
     }

--- a/server.js
+++ b/server.js
@@ -5,7 +5,7 @@ class Server {
   constructor(handler = null) {
     this.handler = handler || new Handler();
     this.hapi = Hapi.server({
-      port: 8888
+      port: 8000
     });
 
     this.setupRoutes();
@@ -32,7 +32,7 @@ class Server {
 
     this.hapi.route({
       method: 'POST',
-      path: '/validate',
+      path: '/message-signature/validate',
       handler: this.handler.validate.bind(this.handler)
     });
 

--- a/test/unit/lib/block.test.js
+++ b/test/unit/lib/block.test.js
@@ -63,14 +63,6 @@ test('is not valid - gt 250 chars', () => {
   expect(block.isValid()).toEqual(false);
 });
 
-test('is not valid - gt 250 chars', () => {
-  let words = 'cc cc bb cc aa aa bb cc cc cc bb cc bb bb cc cc cc aa cc aa bb aa aa aa aa aa aa bb cc aa aa bb aa bb bb cc bb cc bb aa bb bb aa cc aa aa aa aa cc cc cc aa bb aa aa cc aa cc cc bb aa cc cc cc aa bb aa bb cc cc cc aa cc bb bb bb cc bb cc bb cc aa cc aa cc aa aa aa aa aa aa bb aa cc bb bb cc aa aa bb cc aa cc aa bb bb aa aa bb aa cc aa bb aa bb cc cc bb bb bb cc aa cc bb aa bb bb cc bb bb aa cc cc aa bb aa bb bb aa cc cc cc bb bb bb cc bb aa bb aa aa aa aa bb cc bb cc cc bb cc aa cc aa bb bb cc aa bb aa cc bb cc cc aa aa bb cc cc cc cc bb bb cc aa bb bb cc aa aa cc cc bb aa bb cc bb aa aa bb bb aa aa cc aa bb bb bb cc cc cc bb cc bb cc cc cc aa bb aa bb cc cc bb cc aa aa bb bb aa cc cc bb bb cc cc cc aa cc cc cc aa bb bb cc cc cc bb cc aa bb bb cc aa cc bb bb aa cc aa cc';
-  let data = { "address": "1JcnVEyQXVJQHBd2sFn3bt4XREixb4CxPF", "star": { "dec": 0, "ra": 0, "story": words } }
-  let block = new Block(data);
-
-  expect(block.isValid()).toEqual(false);
-});
-
 test('is not valid - gt 500 bytes', () => {
   let words = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus vel malesuada sem. Aenean mattis faucibus eleifend. Curabitur non nisi ut dolor interdum feugiat sit amet sit amet lorem. Etiam hendrerit commodo tortor a maximus. Nulla pulvinar vitae velit lacinia rhoncus. Aliquam sed bibendum elit. Maecenas consequat mollis ultrices. Sed orci metus, cursus in lobortis a, posuere eget nulla. Etiam iaculis lorem et tincidunt faucibus. Quisque commodo pulvinar gravida. Sed consequat dui a iaculis laoreet. Sed euismod quam laoreet nunc mattis, quis suscipit ex posuere. Nulla posuere enim massa, vitae ornare lacus sagittis a. Duis sit amet aliquam mauris. Nam ultrices.'
   let data = { "address": "1JcnVEyQXVJQHBd2sFn3bt4XREixb4CxPF", "star": { "dec": 0, "ra": 0, "story": words } }

--- a/test/unit/lib/block.test.js
+++ b/test/unit/lib/block.test.js
@@ -1,8 +1,41 @@
 const Block = require('../../../lib/block');
 
 test('populates body on constructor', () => {
-  let data = 'Satoshi On a Jest';
+  let data = { "address": "1JcnVEyQXVJQHBd2sFn3bt4XREixb4CxPF", "star": { "dec": 0, "ra": 0, "story": "Big Bang just happened" } }
   let block = new Block(data);
 
   expect(block.body).toEqual(data);
-})
+});
+
+test('parses string', () => {
+  let data = {
+    body: {
+      address: "1JcnVEyQXVJQHBd2sFn3bt4XREixb4CxPF",
+      star: {
+        dec: "-26° 29' 25.9",
+        ra: "16h 29m 1.0s",
+        story: "466f756e642073746172207573696e672068747470733a2f2f7777772e676f6f676c652e636f6d2f736b792f",
+      }
+    },
+    height: 1,
+    time: "1539000549",
+    previousBlockHash: "5f6563225ff600f737aa85034d43d401399d70eeccacffe4cd501a101ac1bf49",
+    hash: "8281a87d5f7a18f1f8c9bd5c4160eb4a829389b2533db65fd86162a01d65dea9"
+  }
+
+  let str = JSON.stringify(data);
+
+  let block = new Block("");
+  block.fill(str);
+
+  expect(block).toEqual(data);
+});
+
+test('decode story', () => {
+  let data = { "address": "1JcnVEyQXVJQHBd2sFn3bt4XREixb4CxPF", "star": { "dec": 0, "ra": 0, "story": "466f756e642073746172207573696e672068747470733a2f2f7777772e676f6f676c652e636f6d2f736b792f" } }
+  let block = new Block(data);
+
+  block.decodeStory();
+
+  expect(block.body.star.storyDecoded).toEqual("Found star using https://www.google.com/sky/")
+});

--- a/test/unit/lib/block.test.js
+++ b/test/unit/lib/block.test.js
@@ -1,13 +1,13 @@
 const Block = require('../../../lib/block');
 
-test('populates body on constructor', () => {
+test('constructor', () => {
   let data = { "address": "1JcnVEyQXVJQHBd2sFn3bt4XREixb4CxPF", "star": { "dec": 0, "ra": 0, "story": "Big Bang just happened" } }
   let block = new Block(data);
 
   expect(block.body).toEqual(data);
 });
 
-test('parses string', () => {
+test('fill', () => {
   let data = {
     body: {
       address: "1JcnVEyQXVJQHBd2sFn3bt4XREixb4CxPF",
@@ -39,3 +39,44 @@ test('decode story', () => {
 
   expect(block.body.star.storyDecoded).toEqual("Found star using https://www.google.com/sky/")
 });
+
+test('is valid', () => {
+  let data = { "address": "1JcnVEyQXVJQHBd2sFn3bt4XREixb4CxPF", "star": { "dec": 0, "ra": 0, "story": "Satoshi Nakamoto Rules" } }
+  let block = new Block(data);
+
+  expect(block.isValid()).toEqual(true);
+});
+
+test('is not valid - not ascii chars', () => {
+
+  let data = { "address": "1JcnVEyQXVJQHBd2sFn3bt4XREixb4CxPF", "star": { "dec": 0, "ra": 0, "story": "çatoshí Nákamoto" } }
+  let block = new Block(data);
+
+  expect(block.isValid()).toEqual(false);
+});
+
+test('is not valid - gt 250 chars', () => {
+  let words = 'cc cc bb cc aa aa bb cc cc cc bb cc bb bb cc cc cc aa cc aa bb aa aa aa aa aa aa bb cc aa aa bb aa bb bb cc bb cc bb aa bb bb aa cc aa aa aa aa cc cc cc aa bb aa aa cc aa cc cc bb aa cc cc cc aa bb aa bb cc cc cc aa cc bb bb bb cc bb cc bb cc aa cc aa cc aa aa aa aa aa aa bb aa cc bb bb cc aa aa bb cc aa cc aa bb bb aa aa bb aa cc aa bb aa bb cc cc bb bb bb cc aa cc bb aa bb bb cc bb bb aa cc cc aa bb aa bb bb aa cc cc cc bb bb bb cc bb aa bb aa aa aa aa bb cc bb cc cc bb cc aa cc aa bb bb cc aa bb aa cc bb cc cc aa aa bb cc cc cc cc bb bb cc aa bb bb cc aa aa cc cc bb aa bb cc bb aa aa bb bb aa aa cc aa bb bb bb cc cc cc bb cc bb cc cc cc aa bb aa bb cc cc bb cc aa aa bb bb aa cc cc bb bb cc cc cc aa cc cc cc aa bb bb cc cc cc bb cc aa bb bb cc aa cc bb bb aa cc aa cc';
+  let data = { "address": "1JcnVEyQXVJQHBd2sFn3bt4XREixb4CxPF", "star": { "dec": 0, "ra": 0, "story": words } }
+  let block = new Block(data);
+
+  expect(block.isValid()).toEqual(false);
+});
+
+test('is not valid - gt 250 chars', () => {
+  let words = 'cc cc bb cc aa aa bb cc cc cc bb cc bb bb cc cc cc aa cc aa bb aa aa aa aa aa aa bb cc aa aa bb aa bb bb cc bb cc bb aa bb bb aa cc aa aa aa aa cc cc cc aa bb aa aa cc aa cc cc bb aa cc cc cc aa bb aa bb cc cc cc aa cc bb bb bb cc bb cc bb cc aa cc aa cc aa aa aa aa aa aa bb aa cc bb bb cc aa aa bb cc aa cc aa bb bb aa aa bb aa cc aa bb aa bb cc cc bb bb bb cc aa cc bb aa bb bb cc bb bb aa cc cc aa bb aa bb bb aa cc cc cc bb bb bb cc bb aa bb aa aa aa aa bb cc bb cc cc bb cc aa cc aa bb bb cc aa bb aa cc bb cc cc aa aa bb cc cc cc cc bb bb cc aa bb bb cc aa aa cc cc bb aa bb cc bb aa aa bb bb aa aa cc aa bb bb bb cc cc cc bb cc bb cc cc cc aa bb aa bb cc cc bb cc aa aa bb bb aa cc cc bb bb cc cc cc aa cc cc cc aa bb bb cc cc cc bb cc aa bb bb cc aa cc bb bb aa cc aa cc';
+  let data = { "address": "1JcnVEyQXVJQHBd2sFn3bt4XREixb4CxPF", "star": { "dec": 0, "ra": 0, "story": words } }
+  let block = new Block(data);
+
+  expect(block.isValid()).toEqual(false);
+});
+
+test('is not valid - gt 500 bytes', () => {
+  let words = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus vel malesuada sem. Aenean mattis faucibus eleifend. Curabitur non nisi ut dolor interdum feugiat sit amet sit amet lorem. Etiam hendrerit commodo tortor a maximus. Nulla pulvinar vitae velit lacinia rhoncus. Aliquam sed bibendum elit. Maecenas consequat mollis ultrices. Sed orci metus, cursus in lobortis a, posuere eget nulla. Etiam iaculis lorem et tincidunt faucibus. Quisque commodo pulvinar gravida. Sed consequat dui a iaculis laoreet. Sed euismod quam laoreet nunc mattis, quis suscipit ex posuere. Nulla posuere enim massa, vitae ornare lacus sagittis a. Duis sit amet aliquam mauris. Nam ultrices.'
+  let data = { "address": "1JcnVEyQXVJQHBd2sFn3bt4XREixb4CxPF", "star": { "dec": 0, "ra": 0, "story": words } }
+  let block = new Block(data);
+
+  expect(block.isValid()).toEqual(false);
+});
+
+

--- a/test/unit/lib/chain.test.js
+++ b/test/unit/lib/chain.test.js
@@ -22,7 +22,7 @@ it('locks chain when starting', async () => {
 
 it('generates genesis block', async (done) => {
   let chain = new Chain(path + 'chain2');
-  let genesis = {"address": "1JcnVEyQXVJQHBd2sFn3bt4XREixb4CxPF", "star": {"dec": 0, "ra": 0, "story": "5468652054696d65732030302f30302f303020546865204269672042616e67206a7573742068617070656e6564", "storyDecoded": "The Times 00/00/00 The Big Bang just happened"}}
+  let genesis = {"address": "1JcnVEyQXVJQHBd2sFn3bt4XREixb4CxPF", "star": {"dec": 0, "ra": 0, "story": "5468652054696d65732030302f30302f303020546865204269672042616e67206a7573742068617070656e6564" }}
 
   setTimeout(async() => {
     let genesisBlock = await chain.getBlock(0);
@@ -42,8 +42,8 @@ it('increments the block height', async (done) => {
       let height = chain.getBlockHeight();
       expect(height).toEqual(0);
 
-      let b1 = await chain.addBlock(new Block({"address": "1JcnVEyQXVJQHBd2sFn3bt4XREixb4CxPF", "star": {"dec": "+38° 47′ 1″", "ra": "18h 36m 56s", "storyDecoded": "Vega"} }));
-      let b2 = await chain.addBlock(new Block({"address": "1JcnVEyQXVJQHBd2sFn3bt4XREixb4CxPF", "star": {"dec": "-16° 42′ 58″", "ra": "6h 45m 9s", "storyDecoded": "Sirius"} }));
+      let b1 = await chain.addBlock(new Block({"address": "1JcnVEyQXVJQHBd2sFn3bt4XREixb4CxPF", "star": {"dec": "+38° 47′ 1″", "ra": "18h 36m 56s", "story": "Vega"} }));
+      let b2 = await chain.addBlock(new Block({"address": "1JcnVEyQXVJQHBd2sFn3bt4XREixb4CxPF", "star": {"dec": "-16° 42′ 58″", "ra": "6h 45m 9s", "story": "Sirius"} }));
 
       expect(chain.getBlockHeight()).toEqual(2);
 
@@ -57,7 +57,7 @@ it('returns the block info', async (done) => {
 
   setTimeout(async() => {
     let genesisBlock = await chain.getBlock(0);
-    let genesis = {"address": "1JcnVEyQXVJQHBd2sFn3bt4XREixb4CxPF", "star": {"dec": 0, "ra": 0, "story": "5468652054696d65732030302f30302f303020546865204269672042616e67206a7573742068617070656e6564", "storyDecoded": "The Times 00/00/00 The Big Bang just happened"}}
+    let genesis = {"address": "1JcnVEyQXVJQHBd2sFn3bt4XREixb4CxPF", "star": {"dec": 0, "ra": 0, "story": "5468652054696d65732030302f30302f303020546865204269672042616e67206a7573742068617070656e6564"}}
 
     expect(genesisBlock.height).toEqual(0);
     expect(genesisBlock.hash).not.toBeNull();


### PR DESCRIPTION
- Changes port from 8888 to 8000
- Changes validate addres from /validate to /message-signature/validate
- Does not store decoded story on blockchain;
- Decode story on endpoints;
- Add validations: ASCII only, 500 bytes and 250 words.